### PR TITLE
More options for indexing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["./search_backend"]
 
 [project]
 name = "search_backend"
-version = "0.0.3"
+version = "0.0.4"
 requires-python = ">=3.9, <4"
 description = "Modular component for AI-enabled application search backend."
 readme = "README.md"

--- a/search_backend/api/lib/config.py
+++ b/search_backend/api/lib/config.py
@@ -23,6 +23,8 @@ defaults = {
     "OPENSEARCH_URL": "http://localstack:4566",
     "QUERY_SERVICE": "hybrid",
 
+    "index_batch_size": 10,
+
     # Select embedding model for the semantic search. This should be a sentence-similarity
     # model available on Huggingface: https://huggingface.co/models?pipeline_tag=sentence-similarity
     "dense_embedding_model": "snowflake/snowflake-arctic-embed-xs",

--- a/search_backend/api/lib/indexing_pipeline.py
+++ b/search_backend/api/lib/indexing_pipeline.py
@@ -19,6 +19,9 @@ class IndexingPipeline:
             dense_embedding_model: str,
             semantic: bool = False,
             indexing: Pipeline = Pipeline(),
+            split_length: int = 64,
+            split_overlap: int = 8,
+            split_threshold: int = 0
     ):
         """
         :param document_store: DocumentStore object that has been set up elsewhere
@@ -29,7 +32,12 @@ class IndexingPipeline:
         """
         self.document_store = document_store
 
-        document_splitter = DocumentSplitter(split_length=128, split_overlap=32)
+        document_splitter = DocumentSplitter(
+            split_by="word",
+            split_length=split_length,
+            split_overlap=split_overlap,
+            split_threshold=split_threshold,
+        )
 
         indexing.add_component("document_splitter", document_splitter)
 

--- a/search_backend/api/lib/retrieval_pipeline.py
+++ b/search_backend/api/lib/retrieval_pipeline.py
@@ -33,7 +33,11 @@ class RetrievalPipeline:
         self.retrieval = Pipeline()
         self.document_store = document_store
 
-        self.bm25_retriever = OpenSearchBM25Retriever(document_store=self.document_store, scale_score=True)
+        self.bm25_retriever = OpenSearchBM25Retriever(
+            document_store=self.document_store,
+            scale_score=True,
+            fuzziness="AUTO",
+        )
         self.embedding_retriever = OpenSearchEmbeddingRetriever(document_store=self.document_store)
 
         if dense_embedding_model is not None:

--- a/search_backend/api/lib/services.py
+++ b/search_backend/api/lib/services.py
@@ -46,6 +46,7 @@ def document_store_factory(cfg, create_index=False):
     url = cfg["OPENSEARCH_URL"]
     use_ssl = urlparse(url).scheme == "https"
     embedding_dim = cfg["embedding_dim"],
+    batch_size = cfg["index_batch_size"]
 
     # OpenSearch document store
     opensearch_docstore_options = {
@@ -56,6 +57,7 @@ def document_store_factory(cfg, create_index=False):
         "connection_class": Urllib3HttpConnection,
         "index": "document",
         "embedding_dim": embedding_dim,
+        "batch_size": batch_size,
     }
 
     return OpenSearchDocumentStore(create_index=create_index, **opensearch_docstore_options)


### PR DESCRIPTION
 - Defines the `batch_size` arg, so Haystack won't try to index everything in one go.
 - Adds optional args for the document splitter