### PR TITLE
Improve setting of threshold score in search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ for doc in results:
 Hybrid:
 ```
 test_query = "wonder that features plants"
-results = hybrid_search_init.hybrid_search(test_query, top_k=3, threshold=0.00001)
+results = hybrid_search_init.hybrid_search(test_query, bm25_top_k=3, semantic_top_k=3, threshold=0.00001)
 
 for doc in results:
     print(f'{doc.meta["title"]} - Score: {doc.score}')

--- a/notebooks/demo_search.ipynb
+++ b/notebooks/demo_search.ipynb
@@ -20,14 +20,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1",
    "metadata": {
     "jupyter": {
      "is_executing": true
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/chloe.pugh/rd-search-backend/venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "from haystack import Document\n",
@@ -62,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "3",
    "metadata": {},
    "outputs": [],
@@ -102,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "7",
    "metadata": {},
    "outputs": [],
@@ -140,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "10",
    "metadata": {},
    "outputs": [],
@@ -151,12 +160,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "11",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Great Pyramid of Giza - Score: 0.6114707644356653\n",
+      "The Great Pyramid of Giza is the largest Egyptian pyramid. It served as the tomb of pharaoh Khufu, who ruled during the Fourth Dynasty of the Old Kingdom. Built c. 2600 BC, over a period of about 26 years, the pyramid is the oldest of the Seven Wonders of the Ancient World, and the only wonder that has remained largely intact. It is the most \n",
+      "Hanging Gardens of Babylon - Score: 0.5952300196552911\n",
+      "to have been built in the ancient city of Babylon, near present-day Hillah, Babil province, in Iraq. The Hanging Gardens' name is derived from the Greek word κρεμαστός (kremastós, lit. 'overhanging'), which has a broader meaning than the modern English word 'hanging' and refers to trees being planted on a raised structure such as a terrace.\n",
+      "Colossus of Rhodes - Score: 0.5276781669100258\n",
+      "Wonders of the Ancient World, it was constructed to celebrate the successful defence of Rhodes city against an attack by Demetrius I of Macedon, who had besieged it for a year with a large army and navy.\n"
+     ]
+    }
+   ],
    "source": [
     "test_query = \"lighthouse\"\n",
+    "# test_query = \"wonder that features plants\"\n",
     "results = bm25_search_init.bm25_search(test_query, top_k=3)\n",
     "\n",
     "for doc in results:\n",
@@ -175,6 +198,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ab33bee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "13",
    "metadata": {},
@@ -184,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "14",
    "metadata": {},
    "outputs": [],
@@ -199,10 +232,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "15",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running search...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Calculating embeddings: 100%|██████████| 1/1 [00:00<00:00, 49.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hanging Gardens of Babylon - Score: 3.407466283533722e-05\n",
+      "The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World listed by Hellenic culture. They were described as a remarkable feat of engineering with an ascending series of tiered gardens containing a wide variety of trees, shrubs, and vines, resembling a large green mountain constructed of mud bricks. It was said to have been built in the ancient city \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "test_query = \"wonder that features plants\"\n",
     "results = semantic_search_init.semantic_search(test_query, top_k=3, threshold=0.00001)\n",
@@ -222,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "17",
    "metadata": {},
    "outputs": [],
@@ -237,13 +300,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "18",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Calculating embeddings: 100%|██████████| 1/1 [00:00<00:00, 54.12it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hanging Gardens of Babylon - Score: 0.9838709677419354\n",
+      "to have been built in the ancient city of Babylon, near present-day Hillah, Babil province, in Iraq. The Hanging Gardens' name is derived from the Greek word κρεμαστός (kremastós, lit. 'overhanging'), which has a broader meaning than the modern English word 'hanging' and refers to trees being planted on a raised structure such as a terrace.\n",
+      "Hanging Gardens of Babylon - Score: 0.9692307692307693\n",
+      "The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World listed by Hellenic culture. They were described as a remarkable feat of engineering with an ascending series of tiered gardens containing a wide variety of trees, shrubs, and vines, resembling a large green mountain constructed of mud bricks. It was said to have been built in the ancient city \n",
+      "Great Pyramid of Giza - Score: 0.5\n",
+      "The Great Pyramid of Giza is the largest Egyptian pyramid. It served as the tomb of pharaoh Khufu, who ruled during the Fourth Dynasty of the Old Kingdom. Built c. 2600 BC, over a period of about 26 years, the pyramid is the oldest of the Seven Wonders of the Ancient World, and the only wonder that has remained largely intact. It is the most \n",
+      "Colossus of Rhodes - Score: 0.4841269841269841\n",
+      "Wonders of the Ancient World, it was constructed to celebrate the successful defence of Rhodes city against an attack by Demetrius I of Macedon, who had besieged it for a year with a large army and navy.\n",
+      "Mausoleum at Halicarnassus - Score: 0.4841269841269841\n",
+      "the Greek architects Satyros and Pythius of Priene. Its elevated tomb structure is derived from the tombs of neighbouring Lycia, a territory Mausolus had invaded and annexed c. 360 BC, such as the Nereid Monument.\n",
+      "Lighthouse of Alexandria - Score: 0.4765625\n",
+      "been estimated to have been at least 100 metres (330 ft) in overall height. One of the Seven Wonders of the Ancient World, for many centuries it was one of the tallest man-made structures in the world.\n",
+      "Colossus of Rhodes - Score: 0.4621212121212121\n",
+      "The Colossus of Rhodes (Ancient Greek: ὁ Κολοσσὸς Ῥόδιος, romanized: ho Kolossòs Rhódios; Modern Greek: Κολοσσός της Ρόδου, romanized: Kolossós tis Ródou) was a statue of the Greek sun god Helios, erected in the city of Rhodes, on the Greek island of the same name, by Chares of Lindos in 280 BC. One of the Seven Wonders of the Ancient World, it was constructed \n"
+     ]
+    }
+   ],
    "source": [
     "test_query = \"wonder that features plants\"\n",
-    "results = hybrid_search_init.hybrid_search(test_query, top_k=3, threshold=0.00001)\n",
+    "results = hybrid_search_init.hybrid_search(test_query, bm25_top_k=3, semantic_top_k=3, threshold=0.000001)\n",
     "\n",
     "for doc in results:\n",
     "    print(f'{doc.meta[\"title\"]} - Score: {doc.score}')\n",
@@ -252,6 +343,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Search backend",
+   "language": "python",
+   "name": "venv_search"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/demo_search.ipynb
+++ b/notebooks/demo_search.ipynb
@@ -20,23 +20,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1",
    "metadata": {
     "jupyter": {
      "is_executing": true
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/chloe.pugh/rd-search-backend/venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "from haystack import Document\n",
@@ -71,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3",
    "metadata": {},
    "outputs": [],
@@ -111,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7",
    "metadata": {},
    "outputs": [],
@@ -149,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "10",
    "metadata": {},
    "outputs": [],
@@ -160,23 +151,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "11",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Great Pyramid of Giza - Score: 0.6114707644356653\n",
-      "The Great Pyramid of Giza is the largest Egyptian pyramid. It served as the tomb of pharaoh Khufu, who ruled during the Fourth Dynasty of the Old Kingdom. Built c. 2600 BC, over a period of about 26 years, the pyramid is the oldest of the Seven Wonders of the Ancient World, and the only wonder that has remained largely intact. It is the most \n",
-      "Hanging Gardens of Babylon - Score: 0.5952300196552911\n",
-      "to have been built in the ancient city of Babylon, near present-day Hillah, Babil province, in Iraq. The Hanging Gardens' name is derived from the Greek word κρεμαστός (kremastós, lit. 'overhanging'), which has a broader meaning than the modern English word 'hanging' and refers to trees being planted on a raised structure such as a terrace.\n",
-      "Colossus of Rhodes - Score: 0.5276781669100258\n",
-      "Wonders of the Ancient World, it was constructed to celebrate the successful defence of Rhodes city against an attack by Demetrius I of Macedon, who had besieged it for a year with a large army and navy.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "test_query = \"lighthouse\"\n",
     "# test_query = \"wonder that features plants\"\n",
@@ -200,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ab33bee",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Run semantic search"
@@ -217,8 +195,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "14",
+   "execution_count": null,
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,40 +210,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "15",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running search...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Calculating embeddings: 100%|██████████| 1/1 [00:00<00:00, 49.36it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hanging Gardens of Babylon - Score: 3.407466283533722e-05\n",
-      "The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World listed by Hellenic culture. They were described as a remarkable feat of engineering with an ascending series of tiered gardens containing a wide variety of trees, shrubs, and vines, resembling a large green mountain constructed of mud bricks. It was said to have been built in the ancient city \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "test_query = \"wonder that features plants\"\n",
     "results = semantic_search_init.semantic_search(test_query, top_k=3, threshold=0.00001)\n",
@@ -277,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Hybrid search"
@@ -285,8 +233,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "17",
+   "execution_count": null,
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,38 +248,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "18",
+   "execution_count": null,
+   "id": "19",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Calculating embeddings: 100%|██████████| 1/1 [00:00<00:00, 54.12it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hanging Gardens of Babylon - Score: 0.9838709677419354\n",
-      "to have been built in the ancient city of Babylon, near present-day Hillah, Babil province, in Iraq. The Hanging Gardens' name is derived from the Greek word κρεμαστός (kremastós, lit. 'overhanging'), which has a broader meaning than the modern English word 'hanging' and refers to trees being planted on a raised structure such as a terrace.\n",
-      "Hanging Gardens of Babylon - Score: 0.9692307692307693\n",
-      "The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World listed by Hellenic culture. They were described as a remarkable feat of engineering with an ascending series of tiered gardens containing a wide variety of trees, shrubs, and vines, resembling a large green mountain constructed of mud bricks. It was said to have been built in the ancient city \n",
-      "Great Pyramid of Giza - Score: 0.5\n",
-      "The Great Pyramid of Giza is the largest Egyptian pyramid. It served as the tomb of pharaoh Khufu, who ruled during the Fourth Dynasty of the Old Kingdom. Built c. 2600 BC, over a period of about 26 years, the pyramid is the oldest of the Seven Wonders of the Ancient World, and the only wonder that has remained largely intact. It is the most \n",
-      "Colossus of Rhodes - Score: 0.4841269841269841\n",
-      "Wonders of the Ancient World, it was constructed to celebrate the successful defence of Rhodes city against an attack by Demetrius I of Macedon, who had besieged it for a year with a large army and navy.\n",
-      "Mausoleum at Halicarnassus - Score: 0.4841269841269841\n",
-      "the Greek architects Satyros and Pythius of Priene. Its elevated tomb structure is derived from the tombs of neighbouring Lycia, a territory Mausolus had invaded and annexed c. 360 BC, such as the Nereid Monument.\n",
-      "Lighthouse of Alexandria - Score: 0.4765625\n",
-      "been estimated to have been at least 100 metres (330 ft) in overall height. One of the Seven Wonders of the Ancient World, for many centuries it was one of the tallest man-made structures in the world.\n",
-      "Colossus of Rhodes - Score: 0.4621212121212121\n",
-      "The Colossus of Rhodes (Ancient Greek: ὁ Κολοσσὸς Ῥόδιος, romanized: ho Kolossòs Rhódios; Modern Greek: Κολοσσός της Ρόδου, romanized: Kolossós tis Ródou) was a statue of the Greek sun god Helios, erected in the city of Rhodes, on the Greek island of the same name, by Chares of Lindos in 280 BC. One of the Seven Wonders of the Ancient World, it was constructed \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "test_query = \"wonder that features plants\"\n",
     "results = hybrid_search_init.hybrid_search(test_query, bm25_top_k=3, semantic_top_k=3, threshold=0.000001)\n",
@@ -343,11 +263,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Search backend",
-   "language": "python",
-   "name": "venv_search"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = ["./search_backend"]
 
 [project]
 name = "search_backend"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.9, <4"
 description = "Modular component for AI-enabled application search backend."
 readme = "README.md"

--- a/search_backend/retrieval_pipeline.py
+++ b/search_backend/retrieval_pipeline.py
@@ -73,9 +73,19 @@ class RetrievalPipeline:
 
     def setup_hybrid_pipeline(self) -> Pipeline:
         """
-        This function sets up the hybrid retrieval pipeline based on an existing document store.
+        This function sets up the hybrid retrieval pipeline based on an existing document
+        store.
 
-        :return: Returns the pipeline object which can then be used to search the data for matches to a particular query.
+        Notes:
+         - Although a reranker is used, it is only applied to the dense embedding retrieval
+           (prior to joining with results from the BM25 retrieval). This is because the
+           pipeline is set up to allow all matches to be returned from the BM25 retrieval,
+           and if there are many matches it would cause the reranking stage to be very slow.
+         - Results from the BM25 and embedding retrieval are joined using reciprocal rank
+           fusion
+
+        :return: Returns the pipeline object which can then be used to search the data for
+            matches to a particular query.
         """
 
         self.retrieval.add_component(

--- a/search_backend/retrieval_pipeline.py
+++ b/search_backend/retrieval_pipeline.py
@@ -16,6 +16,7 @@ from haystack_integrations.components.retrievers.opensearch import (
 from haystack_integrations.document_stores.opensearch import (
     OpenSearchDocumentStore,
 )
+from search_backend.threshold_score import ThresholdScore
 
 
 class RetrievalPipeline:
@@ -85,11 +86,12 @@ class RetrievalPipeline:
             "embedding_retriever", self.embedding_retriever
         )
         self.retrieval.add_component(
+            "ranker", TransformersSimilarityRanker(model=self.rerank_model)
+        )
+        self.retrieval.add_component("semantic_threshold", ThresholdScore())
+        self.retrieval.add_component(
             "document_joiner",
             DocumentJoiner(join_mode="reciprocal_rank_fusion"),
-        )
-        self.retrieval.add_component(
-            "ranker", TransformersSimilarityRanker(model=self.rerank_model)
         )
 
         self.retrieval.connect(
@@ -97,8 +99,9 @@ class RetrievalPipeline:
             "embedding_retriever.query_embedding",
         )
         self.retrieval.connect("bm25_retriever", "document_joiner")
-        self.retrieval.connect("embedding_retriever", "document_joiner")
-        self.retrieval.connect("document_joiner", "ranker")
+        self.retrieval.connect("embedding_retriever", "ranker")
+        self.retrieval.connect("ranker", "semantic_threshold.documents")  
+        self.retrieval.connect("semantic_threshold", "document_joiner")
 
         return self.retrieval
 
@@ -118,12 +121,14 @@ class RetrievalPipeline:
         self.retrieval.add_component(
             "ranker", TransformersSimilarityRanker(model=self.rerank_model)
         )
+        self.retrieval.add_component("threshold", ThresholdScore())
 
         self.retrieval.connect(
             "dense_text_embedder.embedding",
             "embedding_retriever.query_embedding",
         )
         self.retrieval.connect("embedding_retriever", "ranker")
+        self.retrieval.connect("ranker", "threshold.documents")
 
         return self.retrieval
 

--- a/search_backend/retrieval_pipeline.py
+++ b/search_backend/retrieval_pipeline.py
@@ -100,7 +100,7 @@ class RetrievalPipeline:
         )
         self.retrieval.connect("bm25_retriever", "document_joiner")
         self.retrieval.connect("embedding_retriever", "ranker")
-        self.retrieval.connect("ranker", "semantic_threshold.documents")  
+        self.retrieval.connect("ranker", "semantic_threshold.documents")
         self.retrieval.connect("semantic_threshold", "document_joiner")
 
         return self.retrieval

--- a/search_backend/search.py
+++ b/search_backend/search.py
@@ -35,7 +35,8 @@ class Search:
         self,
         search_query: str,
         filters: dict = None,
-        top_k: int = 10,
+        bm25_top_k: int = None,
+        semantic_top_k: int = 10,
         threshold: float = 0.0,
     ):
         """
@@ -67,31 +68,27 @@ class Search:
                 "bm25_retriever": {
                     "query": search_query,
                     "filters": filters,
-                    "top_k": top_k,
+                    "top_k": bm25_top_k,
                 },
                 "embedding_retriever": {
                     "filters": filters,
-                    "top_k": top_k,
+                    "top_k": semantic_top_k,
                 },
-                "ranker": {"query": search_query, "top_k": top_k},
+                "ranker": {"query": search_query},
+                "semantic_threshold": {"score_threshold": threshold},
+                
             }
         )
 
         # Return an empty list if an unexpected object is returned by the pipeline
         if prediction is None:
             return []
-        elif "ranker" not in prediction:
+        elif "document_joiner" not in prediction:
             return []
-        elif "documents" not in prediction["ranker"]:
+        elif "documents" not in prediction["document_joiner"]:
             return []
         else:
-            results = prediction["ranker"]["documents"]
-
-        # Filter by threshold score
-        if threshold > 0:
-            results = [
-                result for result in results if result.score > threshold
-            ]
+            results = prediction["document_joiner"]["documents"]
 
         return results
 
@@ -134,24 +131,25 @@ class Search:
                     "top_k": top_k,
                 },
                 "ranker": {"query": search_query, "top_k": top_k},
+                "threshold": {"score_threshold": threshold}
             }
         )
 
         # Return an empty list if an unexpected object is returned by the pipeline
         if prediction is None:
             return []
-        elif "ranker" not in prediction:
+        elif "threshold" not in prediction:
             return []
-        elif "documents" not in prediction["ranker"]:
+        elif "documents" not in prediction["threshold"]:
             return []
         else:
-            results = prediction["ranker"]["documents"]
+            results = prediction["threshold"]["documents"]
 
-        # Filter by threshold score
-        if threshold > 0:
-            results = [
-                result for result in results if result.score > threshold
-            ]
+        # # Filter by threshold score
+        # if threshold > 0:
+        #     results = [
+        #         result for result in results if result.score > threshold
+        #     ]
 
         return results
 

--- a/search_backend/search.py
+++ b/search_backend/search.py
@@ -161,12 +161,6 @@ class Search:
         else:
             results = prediction["threshold"]["documents"]
 
-        # # Filter by threshold score
-        # if threshold > 0:
-        #     results = [
-        #         result for result in results if result.score > threshold
-        #     ]
-
         return results
 
     def bm25_search(

--- a/search_backend/search.py
+++ b/search_backend/search.py
@@ -63,7 +63,8 @@ class Search:
         :param top_k: How many results to return from the overall hybrid retrieval (if None
             then the upper limit for the total number of results will be bm25_top_k +
             semantic_top_k).
-        :param threshold: Set a threshold match score (between 0 and 1) for the semantic search.
+        :param threshold: Set a threshold match score (a float between 0 and 1) for the
+            semantic search.
 
         :return: A list of ranked search results.
         """
@@ -127,7 +128,8 @@ class Search:
             }
             ```
         :param top_k: How many results to return.
-        :param threshold: Set a threshold match score (between 0 and 1)
+        :param threshold: Set a threshold match score (a float between 0 and 1) for the
+            semantic search.
 
         :return: A list of ranked search results.
         """

--- a/search_backend/search.py
+++ b/search_backend/search.py
@@ -53,7 +53,9 @@ class Search:
                 ],
             }
             ```
-        :param top_k: How many results to return.
+        :param bm25_top_k: How many results to return from the BM25 retrieval (set to None
+            to retrieve all).
+        :param semantic_top_k: How many results to return from the dense embedding retrieval.
         :param threshold: Set a threshold match score (between 0 and 1)
 
         :return: A list of ranked search results.

--- a/search_backend/search.py
+++ b/search_backend/search.py
@@ -76,7 +76,6 @@ class Search:
                 },
                 "ranker": {"query": search_query},
                 "semantic_threshold": {"score_threshold": threshold},
-                
             }
         )
 
@@ -131,7 +130,7 @@ class Search:
                     "top_k": top_k,
                 },
                 "ranker": {"query": search_query, "top_k": top_k},
-                "threshold": {"score_threshold": threshold}
+                "threshold": {"score_threshold": threshold},
             }
         )
 

--- a/search_backend/search.py
+++ b/search_backend/search.py
@@ -35,12 +35,14 @@ class Search:
         self,
         search_query: str,
         filters: dict = None,
-        bm25_top_k: int = None,
+        bm25_top_k: int = 10,
         semantic_top_k: int = 10,
+        top_k: int = None,
         threshold: float = 0.0,
-    ):
+    ) -> list:
         """
-        Run a hybrid search pipeline and return results.
+        Run a hybrid search pipeline and return results. See `setup_hybrid_pipeline()`
+        for details on the hybrid search pipeline.
 
         :param search_query: The search query in the form of a text string.
         :param filters: Metadata filters. These should be formatted like:
@@ -53,10 +55,15 @@ class Search:
                 ],
             }
             ```
-        :param bm25_top_k: How many results to return from the BM25 retrieval (set to None
-            to retrieve all).
+        :param bm25_top_k: How many results to return from the BM25 retrieval (the
+            OpenSearchBM25Retriever class that this is based on has a default top_k of 10,
+            so set this to a value equal to the number of records in the document store to
+            retrieve all matches).
         :param semantic_top_k: How many results to return from the dense embedding retrieval.
-        :param threshold: Set a threshold match score (between 0 and 1)
+        :param top_k: How many results to return from the overall hybrid retrieval (if None
+            then the upper limit for the total number of results will be bm25_top_k +
+            semantic_top_k).
+        :param threshold: Set a threshold match score (between 0 and 1) for the semantic search.
 
         :return: A list of ranked search results.
         """
@@ -76,7 +83,10 @@ class Search:
                     "filters": filters,
                     "top_k": semantic_top_k,
                 },
-                "ranker": {"query": search_query},
+                "ranker": {
+                    "query": search_query,
+                    "top_k": semantic_top_k,
+                },
                 "semantic_threshold": {"score_threshold": threshold},
             }
         )
@@ -90,6 +100,8 @@ class Search:
             return []
         else:
             results = prediction["document_joiner"]["documents"]
+            if top_k is not None:
+                results = results[:top_k]
 
         return results
 
@@ -99,7 +111,7 @@ class Search:
         filters: dict = None,
         top_k: int = 10,
         threshold: float = 0.0,
-    ):
+    ) -> list:
         """
         Run a semantic search pipeline and return results.
 
@@ -131,7 +143,10 @@ class Search:
                     "filters": filters,
                     "top_k": top_k,
                 },
-                "ranker": {"query": search_query, "top_k": top_k},
+                "ranker": {
+                    "query": search_query,
+                    "top_k": top_k,
+                },
                 "threshold": {"score_threshold": threshold},
             }
         )
@@ -155,8 +170,8 @@ class Search:
         return results
 
     def bm25_search(
-        self, search_query: str, filters: dict = None, top_k: int = 100
-    ):
+        self, search_query: str, filters: dict = None, top_k: int = 10
+    ) -> list:
         """
         Run a BM25 search pipeline and return results.
 

--- a/search_backend/threshold_score.py
+++ b/search_backend/threshold_score.py
@@ -16,7 +16,7 @@ class ThresholdScore:
 
         if score_threshold < 0 or score_threshold > 1:
             raise ValueError(
-                f"threshold must be between 0 and 1 (inclusive), but got {score_threshold}"
+                f"score_threshold must be a float between 0 and 1 (inclusive), but got {score_threshold}"
             )
 
         return {

--- a/search_backend/threshold_score.py
+++ b/search_backend/threshold_score.py
@@ -1,0 +1,34 @@
+from haystack import Document, component, default_from_dict, default_to_dict
+from typing import List, Dict, Optional, Any
+
+
+@component
+class ThresholdScore:
+    """
+    A Haystack component to filter results based on a threshold match score.
+    """
+
+    def __init__(
+        self,
+        score_threshold: float = 0.0 
+    ):
+        
+        self.score_threshold = score_threshold
+
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        documents: List[Document],
+        score_threshold: Optional[float] = None
+    ):
+        
+        if not documents:
+            return {"documents": []}
+        
+        score_threshold = score_threshold or self.score_threshold
+
+        if score_threshold < 0 or score_threshold > 1:
+            raise ValueError(f"threshold must be between 0 and 1 (inclusive), but got {score_threshold}")
+
+        return {"documents": [doc for doc in documents if doc.score > score_threshold]}

--- a/search_backend/threshold_score.py
+++ b/search_backend/threshold_score.py
@@ -8,26 +8,16 @@ class ThresholdScore:
     A Haystack component to filter results based on a threshold match score.
     """
 
-    def __init__(
-        self,
-        score_threshold: float = 0.0 
-    ):
-        
-        self.score_threshold = score_threshold
-
-
     @component.output_types(documents=List[Document])
     def run(
         self,
         documents: List[Document],
-        score_threshold: Optional[float] = None
+        score_threshold: float = 0.0
     ):
         
         if not documents:
             return {"documents": []}
         
-        score_threshold = score_threshold or self.score_threshold
-
         if score_threshold < 0 or score_threshold > 1:
             raise ValueError(f"threshold must be between 0 and 1 (inclusive), but got {score_threshold}")
 

--- a/search_backend/threshold_score.py
+++ b/search_backend/threshold_score.py
@@ -9,16 +9,18 @@ class ThresholdScore:
     """
 
     @component.output_types(documents=List[Document])
-    def run(
-        self,
-        documents: List[Document],
-        score_threshold: float = 0.0
-    ):
-        
+    def run(self, documents: List[Document], score_threshold: float = 0.0):
+
         if not documents:
             return {"documents": []}
-        
-        if score_threshold < 0 or score_threshold > 1:
-            raise ValueError(f"threshold must be between 0 and 1 (inclusive), but got {score_threshold}")
 
-        return {"documents": [doc for doc in documents if doc.score > score_threshold]}
+        if score_threshold < 0 or score_threshold > 1:
+            raise ValueError(
+                f"threshold must be between 0 and 1 (inclusive), but got {score_threshold}"
+            )
+
+        return {
+            "documents": [
+                doc for doc in documents if doc.score > score_threshold
+            ]
+        }

--- a/tests/retrieval_pipeline_test.py
+++ b/tests/retrieval_pipeline_test.py
@@ -16,6 +16,7 @@ from haystack_integrations.document_stores.opensearch import (
 from mockito import mock, when, verify, any
 
 from search_backend.retrieval_pipeline import RetrievalPipeline
+from search_backend.threshold_score import ThresholdScore
 
 
 class TestRetrievalPipeline(unittest.TestCase):
@@ -57,18 +58,23 @@ class TestRetrievalPipeline(unittest.TestCase):
             "embedding_retriever", any(OpenSearchEmbeddingRetriever)
         )
         verify(mock_pipeline).add_component(
-            "document_joiner", any(DocumentJoiner)
-        )
-        verify(mock_pipeline).add_component(
             "ranker", any(TransformersSimilarityRanker)
         )
+        verify(mock_pipeline).add_component(
+            "semantic_threshold", any(ThresholdScore)
+        )
+        verify(mock_pipeline).add_component(
+            "document_joiner", any(DocumentJoiner)
+        )
+
         verify(mock_pipeline).connect(
             "dense_text_embedder.embedding",
             "embedding_retriever.query_embedding",
         )
         verify(mock_pipeline).connect("bm25_retriever", "document_joiner")
-        verify(mock_pipeline).connect("embedding_retriever", "document_joiner")
-        verify(mock_pipeline).connect("document_joiner", "ranker")
+        verify(mock_pipeline).connect("embedding_retriever", "ranker")
+        verify(mock_pipeline).connect("ranker", "semantic_threshold.documents")
+        verify(mock_pipeline).connect("semantic_threshold", "document_joiner")
 
     def test_setup_semantic_pipeline(self):
         """
@@ -93,11 +99,15 @@ class TestRetrievalPipeline(unittest.TestCase):
         verify(mock_pipeline).add_component(
             "ranker", any(TransformersSimilarityRanker)
         )
+        verify(mock_pipeline).add_component(
+            "threshold", any(ThresholdScore)
+        )
         verify(mock_pipeline).connect(
             "dense_text_embedder.embedding",
             "embedding_retriever.query_embedding",
         )
         verify(mock_pipeline).connect("embedding_retriever", "ranker")
+        verify(mock_pipeline).connect("ranker", "threshold.documents")
 
     def test_setup_bm25_pipeline(self):
         """

--- a/tests/retrieval_pipeline_test.py
+++ b/tests/retrieval_pipeline_test.py
@@ -99,9 +99,7 @@ class TestRetrievalPipeline(unittest.TestCase):
         verify(mock_pipeline).add_component(
             "ranker", any(TransformersSimilarityRanker)
         )
-        verify(mock_pipeline).add_component(
-            "threshold", any(ThresholdScore)
-        )
+        verify(mock_pipeline).add_component("threshold", any(ThresholdScore))
         verify(mock_pipeline).connect(
             "dense_text_embedder.embedding",
             "embedding_retriever.query_embedding",

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -138,127 +138,127 @@ class TestSearch(unittest.TestCase):
         )
         verify(hybrid_pipeline_init).hybrid_search(...)
 
-    def test_hybrid_search_threshold_filter(self):
-        """
-        Test that only search results with a score over a defined threshold are returned by the hybrid search.
-        """
+    # def test_hybrid_search_threshold_filter(self):
+    #     """
+    #     Test that only search results with a score over a defined threshold are returned by the hybrid search.
+    #     """
 
-        # Create a fresh mock pipeline
-        mock_pipeline = self.create_mock_pipeline()
+    #     # Create a fresh mock pipeline
+    #     mock_pipeline = self.create_mock_pipeline()
 
-        # Mock the search results
-        mock_prediction = [
-            {"content": "high score", "score": 0.8},
-            {"content": "low score", "score": 0.4},
-        ]
-        mock_prediction = {
-            "ranker": {
-                "documents": [
-                    Document(content=doc["content"], score=doc["score"])
-                    for doc in mock_prediction
-                ]
-            }
-        }
+    #     # Mock the search results
+    #     mock_prediction = [
+    #         {"content": "high score", "score": 0.8},
+    #         {"content": "low score", "score": 0.4},
+    #     ]
+    #     mock_prediction = {
+    #         "document_joiner": {
+    #             "documents": [
+    #                 Document(content=doc["content"], score=doc["score"])
+    #                 for doc in mock_prediction
+    #             ]
+    #         }
+    #     }
 
-        # Set up the Search instance
-        hybrid_pipeline = RetrievalPipeline(
-            self.mock_document_store,
-            self.dense_embedding_model,
-            self.rerank_model,
-            retrieval=mock_pipeline,
-        ).setup_hybrid_pipeline()
+    #     # Set up the Search instance
+    #     hybrid_pipeline = RetrievalPipeline(
+    #         self.mock_document_store,
+    #         self.dense_embedding_model,
+    #         self.rerank_model,
+    #         retrieval=mock_pipeline,
+    #     ).setup_hybrid_pipeline()
 
-        # Mock the part where the retrieval pipeline is run
-        when(mock_pipeline).run(...).thenReturn(mock_prediction)
-        hybrid_pipeline_init = Search(hybrid_pipeline)
+    #     # Mock the part where the retrieval pipeline is run
+    #     when(mock_pipeline).run(...).thenReturn(mock_prediction)
+    #     hybrid_pipeline_init = Search(hybrid_pipeline)
 
-        # Use a threshold where we expect 2 results
-        threshold = 0.1
-        results = hybrid_pipeline_init.hybrid_search(
-            "test query", threshold=threshold
-        )
+    #     # Use a threshold where we expect 2 results
+    #     threshold = 0.1
+    #     results = hybrid_pipeline_init.hybrid_search(
+    #         "test query", threshold=threshold
+    #     )
 
-        self.assertEqual(
-            len(results), 2, f"Expected 2 results but got {len(results)}"
-        )
+    #     self.assertEqual(
+    #         len(results), 2, f"Expected 2 results but got {len(results)}"
+    #     )
 
-        # Use a threshold where we expect 1 result
-        threshold = 0.4
-        results = hybrid_pipeline_init.hybrid_search(
-            "test query", threshold=threshold
-        )
+    #     # Use a threshold where we expect 1 result
+    #     threshold = 0.4
+    #     results = hybrid_pipeline_init.hybrid_search(
+    #         "test query", threshold=threshold
+    #     )
 
-        self.assertEqual(
-            len(results),
-            1,
-            f"Expected 1 result with score above 0.5 but got {len(results)}",
-        )
-        self.assertEqual(
-            results[0].content,
-            "high score",
-            f"Expected content 'high score', got {results[0].content}",
-        )
+    #     self.assertEqual(
+    #         len(results),
+    #         1,
+    #         f"Expected 1 result with score above 0.5 but got {len(results)}",
+    #     )
+    #     self.assertEqual(
+    #         results[0].content,
+    #         "high score",
+    #         f"Expected content 'high score', got {results[0].content}",
+    #     )
 
-        # Use a threshold where we expect 0 results
-        threshold = 0.9
-        results = hybrid_pipeline_init.hybrid_search(
-            "test query", threshold=threshold
-        )
+    #     # Use a threshold where we expect 0 results
+    #     threshold = 0.9
+    #     results = hybrid_pipeline_init.hybrid_search(
+    #         "test query", threshold=threshold
+    #     )
 
-        self.assertEqual(
-            len(results), 0, f"Expected no results but got {len(results)}"
-        )
+    #     self.assertEqual(
+    #         len(results), 0, f"Expected no results but got {len(results)}"
+    #     )
 
-    def test_semantic_search_threshold_filter(self):
-        """
-        Test that only search results with a score over a defined threshold are returned by the semantic search.
-        """
+    # def test_semantic_search_threshold_filter(self):
+    #     """
+    #     Test that only search results with a score over a defined threshold are returned by the semantic search.
+    #     """
 
-        # Create a fresh mock pipeline
-        mock_pipeline = self.create_mock_pipeline()
+    #     # Create a fresh mock pipeline
+    #     mock_pipeline = self.create_mock_pipeline()
 
-        # Mock the search results
-        mock_prediction = [
-            {"content": "high score", "score": 0.8},
-            {"content": "low score", "score": 0.4},
-        ]
-        mock_prediction = {
-            "ranker": {
-                "documents": [
-                    Document(content=doc["content"], score=doc["score"])
-                    for doc in mock_prediction
-                ]
-            }
-        }
+    #     # Mock the search results
+    #     mock_prediction = [
+    #         {"content": "high score", "score": 0.8},
+    #         {"content": "low score", "score": 0.4},
+    #     ]
+    #     mock_prediction = {
+    #         "threshold": {
+    #             "documents": [
+    #                 Document(content=doc["content"], score=doc["score"])
+    #                 for doc in mock_prediction
+    #             ]
+    #         }
+    #     }
 
-        # Set up the Search instance
-        semantic_pipeline = RetrievalPipeline(
-            self.mock_document_store,
-            self.dense_embedding_model,
-            self.rerank_model,
-            retrieval=mock_pipeline,
-        ).setup_semantic_pipeline()
+    #     # Set up the Search instance
+    #     semantic_pipeline = RetrievalPipeline(
+    #         self.mock_document_store,
+    #         self.dense_embedding_model,
+    #         self.rerank_model,
+    #         retrieval=mock_pipeline,
+    #     ).setup_semantic_pipeline()
 
-        # Mock the part where the retrieval pipeline is run
-        when(mock_pipeline).run(...).thenReturn(mock_prediction)
-        semantic_pipeline_init = Search(semantic_pipeline)
+    #     # Mock the part where the retrieval pipeline is run
+    #     when(mock_pipeline).run(...).thenReturn(mock_prediction)
+    #     semantic_pipeline_init = Search(semantic_pipeline)
 
-        # Use a threshold where we expect 1 result
-        threshold = 0.4
-        results = semantic_pipeline_init.semantic_search(
-            "test query", threshold=threshold
-        )
+    #     # Use a threshold where we expect 1 result
+    #     threshold = 0.4
+    #     results = semantic_pipeline_init.semantic_search(
+    #         "test query", threshold=threshold
+    #     )
 
-        self.assertEqual(
-            len(results),
-            1,
-            f"Expected 1 result with score above 0.5 but got {len(results)}",
-        )
-        self.assertEqual(
-            results[0].content,
-            "high score",
-            f"Expected content 'high score', got {results[0].content}",
-        )
+    #     self.assertEqual(
+    #         len(results),
+    #         1,
+    #         f"Expected 1 result with score above 0.5 but got {len(results)}",
+    #     )
+    #     self.assertEqual(
+    #         results[0].content,
+    #         "high score",
+    #         f"Expected content 'high score', got {results[0].content}",
+    #     )
 
     def test_search_invalid_query(self):
         """
@@ -327,7 +327,7 @@ class TestSearch(unittest.TestCase):
         results = Search(retrieval_pipeline).hybrid_search("test query")
 
         # Try with something that's only partially structured correctly
-        when(mock_pipeline).run(...).thenReturn({"ranker": {"A": 1}})
+        when(mock_pipeline).run(...).thenReturn({"document_joiner": {"A": 1}})
         results = Search(retrieval_pipeline).hybrid_search("test query")
 
         self.assertEqual(
@@ -367,7 +367,7 @@ class TestSearch(unittest.TestCase):
         )
 
         # Try with something that's only partially structured correctly
-        when(mock_pipeline).run(...).thenReturn({"ranker": {"A": 1}})
+        when(mock_pipeline).run(...).thenReturn({"threshold": {"A": 1}})
         results = Search(retrieval_pipeline).semantic_search("test query")
 
         self.assertEqual(

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -81,9 +81,8 @@ class TestSearch(unittest.TestCase):
             Document(content=doc["content"], score=doc["score"])
             for doc in mock_prediction
         ]
-        when(semantic_search_init).semantic_search(...).thenReturn(
-            mock_prediction
-        )
+        mock_prediction = {"threshold": {"documents": mock_prediction}}
+        when(mock_pipeline).run(...).thenReturn(mock_prediction)
 
         results = semantic_search_init.semantic_search("test query")
 
@@ -96,7 +95,6 @@ class TestSearch(unittest.TestCase):
             "test result",
             f"Expected content 'test result', got {results[0].content}",
         )
-        verify(semantic_search_init).semantic_search(...)
 
     def test_hybrid_search_method(self):
         """
@@ -121,9 +119,8 @@ class TestSearch(unittest.TestCase):
             Document(content=doc["content"], score=doc["score"])
             for doc in mock_prediction
         ]
-        when(hybrid_pipeline_init).hybrid_search(...).thenReturn(
-            mock_prediction
-        )
+        mock_prediction = {"document_joiner": {"documents": mock_prediction}}
+        when(mock_pipeline).run(...).thenReturn(mock_prediction)
 
         results = hybrid_pipeline_init.hybrid_search("test query")
 
@@ -136,129 +133,6 @@ class TestSearch(unittest.TestCase):
             "test result",
             f"Expected content 'test result', got {results[0].content}",
         )
-        verify(hybrid_pipeline_init).hybrid_search(...)
-
-    # def test_hybrid_search_threshold_filter(self):
-    #     """
-    #     Test that only search results with a score over a defined threshold are returned by the hybrid search.
-    #     """
-
-    #     # Create a fresh mock pipeline
-    #     mock_pipeline = self.create_mock_pipeline()
-
-    #     # Mock the search results
-    #     mock_prediction = [
-    #         {"content": "high score", "score": 0.8},
-    #         {"content": "low score", "score": 0.4},
-    #     ]
-    #     mock_prediction = {
-    #         "document_joiner": {
-    #             "documents": [
-    #                 Document(content=doc["content"], score=doc["score"])
-    #                 for doc in mock_prediction
-    #             ]
-    #         }
-    #     }
-
-    #     # Set up the Search instance
-    #     hybrid_pipeline = RetrievalPipeline(
-    #         self.mock_document_store,
-    #         self.dense_embedding_model,
-    #         self.rerank_model,
-    #         retrieval=mock_pipeline,
-    #     ).setup_hybrid_pipeline()
-
-    #     # Mock the part where the retrieval pipeline is run
-    #     when(mock_pipeline).run(...).thenReturn(mock_prediction)
-    #     hybrid_pipeline_init = Search(hybrid_pipeline)
-
-    #     # Use a threshold where we expect 2 results
-    #     threshold = 0.1
-    #     results = hybrid_pipeline_init.hybrid_search(
-    #         "test query", threshold=threshold
-    #     )
-
-    #     self.assertEqual(
-    #         len(results), 2, f"Expected 2 results but got {len(results)}"
-    #     )
-
-    #     # Use a threshold where we expect 1 result
-    #     threshold = 0.4
-    #     results = hybrid_pipeline_init.hybrid_search(
-    #         "test query", threshold=threshold
-    #     )
-
-    #     self.assertEqual(
-    #         len(results),
-    #         1,
-    #         f"Expected 1 result with score above 0.5 but got {len(results)}",
-    #     )
-    #     self.assertEqual(
-    #         results[0].content,
-    #         "high score",
-    #         f"Expected content 'high score', got {results[0].content}",
-    #     )
-
-    #     # Use a threshold where we expect 0 results
-    #     threshold = 0.9
-    #     results = hybrid_pipeline_init.hybrid_search(
-    #         "test query", threshold=threshold
-    #     )
-
-    #     self.assertEqual(
-    #         len(results), 0, f"Expected no results but got {len(results)}"
-    #     )
-
-    # def test_semantic_search_threshold_filter(self):
-    #     """
-    #     Test that only search results with a score over a defined threshold are returned by the semantic search.
-    #     """
-
-    #     # Create a fresh mock pipeline
-    #     mock_pipeline = self.create_mock_pipeline()
-
-    #     # Mock the search results
-    #     mock_prediction = [
-    #         {"content": "high score", "score": 0.8},
-    #         {"content": "low score", "score": 0.4},
-    #     ]
-    #     mock_prediction = {
-    #         "threshold": {
-    #             "documents": [
-    #                 Document(content=doc["content"], score=doc["score"])
-    #                 for doc in mock_prediction
-    #             ]
-    #         }
-    #     }
-
-    #     # Set up the Search instance
-    #     semantic_pipeline = RetrievalPipeline(
-    #         self.mock_document_store,
-    #         self.dense_embedding_model,
-    #         self.rerank_model,
-    #         retrieval=mock_pipeline,
-    #     ).setup_semantic_pipeline()
-
-    #     # Mock the part where the retrieval pipeline is run
-    #     when(mock_pipeline).run(...).thenReturn(mock_prediction)
-    #     semantic_pipeline_init = Search(semantic_pipeline)
-
-    #     # Use a threshold where we expect 1 result
-    #     threshold = 0.4
-    #     results = semantic_pipeline_init.semantic_search(
-    #         "test query", threshold=threshold
-    #     )
-
-    #     self.assertEqual(
-    #         len(results),
-    #         1,
-    #         f"Expected 1 result with score above 0.5 but got {len(results)}",
-    #     )
-    #     self.assertEqual(
-    #         results[0].content,
-    #         "high score",
-    #         f"Expected content 'high score', got {results[0].content}",
-    #     )
 
     def test_search_invalid_query(self):
         """

--- a/tests/threshold_score_test.py
+++ b/tests/threshold_score_test.py
@@ -15,7 +15,7 @@ class TestThresholdScore(unittest.TestCase):
         self.mock_document_store = mock(OpenSearchDocumentStore)
         self.dense_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
         self.rerank_model = "cross-encoder/ms-marco-MiniLM-L-2-v2"
-        
+
         # Mock some search results
         mock_prediction = [
             {"content": "high score", "score": 0.8},
@@ -26,7 +26,6 @@ class TestThresholdScore(unittest.TestCase):
             for doc in mock_prediction
         ]
 
-
     def test_threshold_score_filter(self):
         """
         Test that only search results with a score over a defined threshold are returned by the search.
@@ -34,7 +33,9 @@ class TestThresholdScore(unittest.TestCase):
 
         # Use a threshold where we expect 1 result
         threshold = 0.4
-        results = ThresholdScore().run(documents=self.mock_prediction, score_threshold=threshold)
+        results = ThresholdScore().run(
+            documents=self.mock_prediction, score_threshold=threshold
+        )
         results = results["documents"]
 
         self.assertEqual(
@@ -55,11 +56,15 @@ class TestThresholdScore(unittest.TestCase):
 
         threshold = -1
         with self.assertRaises(ValueError):
-            ThresholdScore().run(documents=self.mock_prediction, score_threshold=threshold)
+            ThresholdScore().run(
+                documents=self.mock_prediction, score_threshold=threshold
+            )
 
         threshold = 1.1
         with self.assertRaises(ValueError):
-            ThresholdScore().run(documents=self.mock_prediction, score_threshold=threshold)
+            ThresholdScore().run(
+                documents=self.mock_prediction, score_threshold=threshold
+            )
 
     def test_no_input(self):
         """

--- a/tests/threshold_score_test.py
+++ b/tests/threshold_score_test.py
@@ -1,0 +1,93 @@
+import unittest
+from haystack import Pipeline, Document
+from haystack_integrations.document_stores.opensearch import (
+    OpenSearchDocumentStore,
+)
+from mockito import mock, when, verify, any
+from search_backend.retrieval_pipeline import RetrievalPipeline
+from search_backend.search import Search
+from search_backend.threshold_score import ThresholdScore
+
+
+class TestThresholdScore(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_document_store = mock(OpenSearchDocumentStore)
+        self.dense_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+        self.rerank_model = "cross-encoder/ms-marco-MiniLM-L-2-v2"
+        
+        # Mock some search results
+        mock_prediction = [
+            {"content": "high score", "score": 0.8},
+            {"content": "low score", "score": 0.4},
+        ]
+        self.mock_prediction = [
+            Document(content=doc["content"], score=doc["score"])
+            for doc in mock_prediction
+        ]
+
+
+    def test_threshold_score_filter(self):
+        """
+        Test that only search results with a score over a defined threshold are returned by the search.
+        """
+
+        # Use a threshold where we expect 1 result
+        threshold = 0.4
+        results = ThresholdScore().run(documents=self.mock_prediction, score_threshold=threshold)
+        results = results["documents"]
+
+        self.assertEqual(
+            len(results),
+            1,
+            f"Expected 1 result with score above 0.5 but got {len(results)}",
+        )
+        self.assertEqual(
+            results[0].content,
+            "high score",
+            f"Expected content 'high score', got {results[0].content}",
+        )
+
+    def test_threshold_out_of_range(self):
+        """
+        Test that an error is raised if threshold scores outside the range 0-1 are defined
+        """
+
+        threshold = -1
+        with self.assertRaises(ValueError):
+            ThresholdScore().run(documents=self.mock_prediction, score_threshold=threshold)
+
+        threshold = 1.1
+        with self.assertRaises(ValueError):
+            ThresholdScore().run(documents=self.mock_prediction, score_threshold=threshold)
+
+    def test_no_input(self):
+        """
+        Test that an empty object is returned when no documents are provided
+        """
+
+        docs = []
+        results = ThresholdScore().run(documents=docs, score_threshold=0)
+
+        self.assertEqual(
+            results,
+            {"documents": []},
+            f"Expected empty list in dictionary, but got {results}",
+        )
+        docs = []
+        results = ThresholdScore().run(documents=docs, score_threshold=0)
+
+        self.assertEqual(
+            results,
+            {"documents": []},
+            f"Expected empty list in dictionary, but got {results}",
+        )
+
+        docs = None
+        results = ThresholdScore().run(documents=docs, score_threshold=0)
+
+        self.assertEqual(
+            results,
+            {"documents": []},
+            f"Expected empty list in dictionary, but got {results}",
+        )


### PR DESCRIPTION
Makes the hybrid search more flexible by adding the following:
 - a Haystack custom component to allow a threshold match score to be set prior to joining the BM25 and dense embedding retrieval results
 - two additional `top_k` args: `bm25_top_k` and `semantic_top_k`. This will enable all BM25 results to be returned in the final output while still constraining results from the semantic search.